### PR TITLE
feat(yaml-example): add an example to skip turso db test

### DIFF
--- a/.test_config.yaml.example
+++ b/.test_config.yaml.example
@@ -1,1 +1,2 @@
 turso_db_path: "<your-turso-db-test>"
+skip_turso_tests: false


### PR DESCRIPTION

## Description

It was missing in the yaml example how to skip the turso db test


