### PR TITLE
fix(db): execute 'SELECT 1;' to test connection

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -65,11 +66,19 @@ func NewDb(dbPath string) (*Db, error) {
 		return nil, err
 	}
 
-	if err = db.sqlDb.Ping(); err != nil {
+	if err = db.testConnection(); err != nil {
 		return nil, err
 	}
 
 	return &db, nil
+}
+
+func (db *Db) testConnection() error {
+	_, err := db.sqlDb.Exec("SELECT 1;")
+	if err != nil {
+		return fmt.Errorf("failed to connect to database")
+	}
+	return nil
 }
 
 func (db *Db) Close() {


### PR DESCRIPTION
## Description

We were using database/sql Ping method. But it's not implemented by our driver, we should revert this once it implements

## Visual reference

When I try to connect without passing token now
```
$ go run ./cmd/libsql-shell/main.go 'https://luisfvieirasilva@promoted-swordsman-luisfvieirasilva.turso.io' 
Error: failed to connect to database
exit status 1
```

Before
```
go run ./cmd/libsql-shell/main.go 'https://luisfvieirasilva@promoted-swordsman-luisfvieirasilva.turso.io' 
Welcome to LibSQL shell!

Type ".quit" to exit the shell, and ".help" to show all commands

→  select 1;
Error: failed to execute SQL: select 1;
```
