### PR TITLE
Fix/dont suggestion keyworks when everything is accepted

### DIFF
--- a/internal/suggester/suggerter.go
+++ b/internal/suggester/suggerter.go
@@ -8,57 +8,6 @@ import (
 	"github.com/libsql/sqlite-antlr4-parser/sqliteparser"
 )
 
-type tokenStreamInspector struct {
-	*antlr.CommonTokenStream
-
-	parser *sqliteparser.SQLiteParser
-
-	lastUserToken                 antlr.Token
-	expectedTokensAtLastUserInput *antlr.IntervalSet
-	ruleBeforeLastUserInput       int
-}
-
-func (mts *tokenStreamInspector) LA(n int) int {
-	token := mts.CommonTokenStream.LA(n)
-
-	if n == 1 {
-		if nextToken := mts.CommonTokenStream.LA(2); nextToken == antlr.TokenEOF && mts.expectedTokensAtLastUserInput == nil {
-			mts.expectedTokensAtLastUserInput = mts.parser.GetExpectedTokens()
-			mts.lastUserToken = mts.CommonTokenStream.LT(1)
-			mts.ruleBeforeLastUserInput = mts.parser.GetState()
-		}
-	}
-	return token
-}
-
-func (mts *tokenStreamInspector) LT(k int) antlr.Token {
-	token := mts.CommonTokenStream.LT(k)
-
-	if k == 1 {
-		if nextToken := mts.CommonTokenStream.LT(2); nextToken.GetTokenType() == antlr.TokenEOF && mts.expectedTokensAtLastUserInput == nil {
-			mts.expectedTokensAtLastUserInput = mts.parser.GetExpectedTokens()
-			mts.lastUserToken = mts.CommonTokenStream.LT(1)
-			mts.ruleBeforeLastUserInput = mts.parser.GetState()
-		}
-	}
-	return token
-}
-
-func (mts *tokenStreamInspector) getLastInputTokenAndExpectedTokens() (lastInputToken antlr.Token, expectedTokens []int) {
-	if mts.expectedTokensAtLastUserInput == nil {
-		return nil, nil
-	}
-
-	expectedTokens = make([]int, 0)
-	for _, v := range mts.expectedTokensAtLastUserInput.GetIntervals() {
-		for j := v.Start; j < v.Stop; j++ {
-			expectedTokens = append(expectedTokens, j)
-		}
-	}
-
-	return mts.lastUserToken, expectedTokens
-}
-
 func SuggestCompletion(currentInput string) []string {
 	suggestions := make([]string, 0)
 

--- a/internal/suggester/tokenRulesFinder.go
+++ b/internal/suggester/tokenRulesFinder.go
@@ -1,0 +1,37 @@
+package suggester
+
+import (
+	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/libsql/sqlite-antlr4-parser/sqliteparser"
+)
+
+type TokenRulesFinder struct {
+	sqliteparser.BaseSQLiteParserListener
+
+	targetToken antlr.Token
+
+	tokenRules []int
+}
+
+func NewTokenRulesFinder(targetToken antlr.Token) *TokenRulesFinder {
+	return &TokenRulesFinder{targetToken: targetToken, tokenRules: make([]int, 0)}
+}
+
+func (trf *TokenRulesFinder) EnterEveryRule(ctx antlr.ParserRuleContext) {
+	ruleStartTokenIndex := ctx.GetStart().GetTokenIndex()
+	ruleEndTokenIndex := ctx.GetStop().GetTokenIndex()
+	targetTokenIndex := trf.targetToken.GetTokenIndex()
+
+	if ruleStartTokenIndex <= targetTokenIndex && targetTokenIndex <= ruleEndTokenIndex {
+		trf.tokenRules = append(trf.tokenRules, ctx.GetRuleIndex())
+	}
+}
+
+func getTokenRules(tree sqliteparser.IParseContext, targetToken antlr.Token) []int {
+
+	tokenRulesFinder := NewTokenRulesFinder(targetToken)
+
+	antlr.ParseTreeWalkerDefault.Walk(tokenRulesFinder, tree)
+
+	return tokenRulesFinder.tokenRules
+}

--- a/internal/suggester/tokenStringInspector.go
+++ b/internal/suggester/tokenStringInspector.go
@@ -1,0 +1,57 @@
+package suggester
+
+import (
+	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/libsql/sqlite-antlr4-parser/sqliteparser"
+)
+
+type tokenStreamInspector struct {
+	*antlr.CommonTokenStream
+
+	parser *sqliteparser.SQLiteParser
+
+	lastUserToken                 antlr.Token
+	expectedTokensAtLastUserInput *antlr.IntervalSet
+	ruleBeforeLastUserInput       int
+}
+
+func (mts *tokenStreamInspector) LA(n int) int {
+	token := mts.CommonTokenStream.LA(n)
+
+	if n == 1 {
+		if nextToken := mts.CommonTokenStream.LA(2); nextToken == antlr.TokenEOF && mts.expectedTokensAtLastUserInput == nil {
+			mts.expectedTokensAtLastUserInput = mts.parser.GetExpectedTokens()
+			mts.lastUserToken = mts.CommonTokenStream.LT(1)
+			mts.ruleBeforeLastUserInput = mts.parser.GetState()
+		}
+	}
+	return token
+}
+
+func (mts *tokenStreamInspector) LT(k int) antlr.Token {
+	token := mts.CommonTokenStream.LT(k)
+
+	if k == 1 {
+		if nextToken := mts.CommonTokenStream.LT(2); nextToken.GetTokenType() == antlr.TokenEOF && mts.expectedTokensAtLastUserInput == nil {
+			mts.expectedTokensAtLastUserInput = mts.parser.GetExpectedTokens()
+			mts.lastUserToken = mts.CommonTokenStream.LT(1)
+			mts.ruleBeforeLastUserInput = mts.parser.GetState()
+		}
+	}
+	return token
+}
+
+func (mts *tokenStreamInspector) getLastInputTokenAndExpectedTokens() (lastInputToken antlr.Token, expectedTokens []int) {
+	if mts.expectedTokensAtLastUserInput == nil {
+		return nil, nil
+	}
+
+	expectedTokens = make([]int, 0)
+	for _, v := range mts.expectedTokensAtLastUserInput.GetIntervals() {
+		for j := v.Start; j < v.Stop; j++ {
+			expectedTokens = append(expectedTokens, j)
+		}
+	}
+
+	return mts.lastUserToken, expectedTokens
+}


### PR DESCRIPTION
## Description

For the case `select 1 from t<TAB>` our autocompletion were suggesting all SQLite keywords that starts with `t` because SQLite accept everything as a table name.
The solution is to find all rules that contains the last token,then we check if some rule is `any_name`, that is the rule that says "accept anything here". In this cases, we suggest nothing
