### PR TITLE
fix: add a way to cancel running queries in the shell

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -28,6 +29,8 @@ type Db struct {
 	sqlDb     *sql.DB
 	driver    driver
 	urlScheme string
+
+	cancelRunningQuery func()
 }
 
 type StatementsResult struct {
@@ -128,7 +131,10 @@ func (db *Db) executeQuery(query string, statementResultCh chan StatementResult)
 		return true
 	}
 
-	rows, err := db.sqlDb.Query(query)
+	ctx, cancel := context.WithCancel(context.Background())
+	db.cancelRunningQuery = cancel
+
+	rows, err := db.sqlDb.QueryContext(ctx, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "interactive transaction not allowed in HTTP queries") {
 			err = &shellerrors.TransactionNotSupportedError{}
@@ -253,4 +259,10 @@ func readQueryResultSet(queryRows *sql.Rows, statementResultCh chan StatementRes
 	}
 
 	return true
+}
+
+func (db *Db) CancelQuery() {
+	if db.cancelRunningQuery != nil {
+		db.cancelRunningQuery()
+	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -120,6 +120,9 @@ func (db *Db) ExecuteAndPrintStatements(statementsString string, outF io.Writer,
 
 	err = PrintStatementsResult(result, outF, withoutHeader, printMode)
 	if err != nil {
+		if strings.Contains(err.Error(), "context canceled") {
+			err = &shellerrors.CancelQueryContextError{}
+		}
 		return err
 	}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -43,9 +43,27 @@ type StatementResult struct {
 	Err         error
 }
 
+func newStatementResult(columnNames []string, rowCh chan rowResult) *StatementResult {
+	return &StatementResult{ColumnNames: columnNames, RowCh: rowCh}
+}
+
+func newStatementResultWithError(err error) *StatementResult {
+	treatedErr := treatDbError(err)
+	return &StatementResult{Err: treatedErr}
+}
+
 type rowResult struct {
 	Row []interface{}
 	Err error
+}
+
+func newRowResult(row []interface{}) *rowResult {
+	return &rowResult{Row: row}
+}
+
+func newRowResultWithError(err error) *rowResult {
+	treatedErr := treatDbError(err)
+	return &rowResult{Err: treatedErr}
 }
 
 func NewDb(dbPath string) (*Db, error) {
@@ -120,9 +138,6 @@ func (db *Db) ExecuteAndPrintStatements(statementsString string, outF io.Writer,
 
 	err = PrintStatementsResult(result, outF, withoutHeader, printMode)
 	if err != nil {
-		if strings.Contains(err.Error(), "context canceled") {
-			err = &shellerrors.CancelQueryContextError{}
-		}
 		return err
 	}
 
@@ -139,13 +154,11 @@ func (db *Db) executeQuery(query string, statementResultCh chan StatementResult)
 
 	rows, err := db.sqlDb.QueryContext(ctx, query)
 	if err != nil {
-		if strings.Contains(err.Error(), "interactive transaction not allowed in HTTP queries") {
-			err = &shellerrors.TransactionNotSupportedError{}
-		}
+		statementResultCh <- *newStatementResultWithError(err)
 
-		statementResultCh <- StatementResult{Err: err}
 		return false
 	}
+
 	defer rows.Close()
 
 	return readQueryResults(rows, statementResultCh)
@@ -206,7 +219,7 @@ func readQueryResults(queryRows *sql.Rows, statementResultCh chan StatementResul
 	}
 
 	if err := queryRows.Err(); err != nil {
-		statementResultCh <- StatementResult{Err: err}
+		statementResultCh <- *newStatementResultWithError(err)
 		return false
 	}
 
@@ -216,13 +229,13 @@ func readQueryResults(queryRows *sql.Rows, statementResultCh chan StatementResul
 func readQueryResultSet(queryRows *sql.Rows, statementResultCh chan StatementResult) (shouldContinue bool) {
 	columnNames, err := getColumnNames(queryRows)
 	if err != nil {
-		statementResultCh <- StatementResult{Err: err}
+		statementResultCh <- *newStatementResultWithError(err)
 		return false
 	}
 
 	columnTypes, err := getColumnTypes(queryRows)
 	if err != nil {
-		statementResultCh <- StatementResult{Err: err}
+		statementResultCh <- *newStatementResultWithError(err)
 		return false
 	}
 
@@ -239,12 +252,12 @@ func readQueryResultSet(queryRows *sql.Rows, statementResultCh chan StatementRes
 	rowCh := make(chan rowResult)
 	defer close(rowCh)
 
-	statementResultCh <- StatementResult{ColumnNames: columnNames, RowCh: rowCh}
+	statementResultCh <- *newStatementResult(columnNames, rowCh)
 
 	for queryRows.Next() {
 		err = queryRows.Scan(columnPointers...)
 		if err != nil {
-			rowCh <- rowResult{Err: err}
+			rowCh <- *newRowResultWithError(err)
 			return false
 		}
 
@@ -253,11 +266,11 @@ func readQueryResultSet(queryRows *sql.Rows, statementResultCh chan StatementRes
 			val := reflect.ValueOf(ptr).Elem()
 			rowData[i] = val.Interface()
 		}
-		rowCh <- rowResult{Row: rowData}
+		rowCh <- *newRowResult(rowData)
 	}
 
 	if err := queryRows.Err(); err != nil {
-		rowCh <- rowResult{Err: err}
+		rowCh <- *newRowResultWithError(err)
 		return false
 	}
 
@@ -268,4 +281,17 @@ func (db *Db) CancelQuery() {
 	if db.cancelRunningQuery != nil {
 		db.cancelRunningQuery()
 	}
+}
+
+func treatDbError(originalErr error) error {
+	err := originalErr
+
+	if strings.Contains(err.Error(), "interactive transaction not allowed in HTTP queries") {
+		err = &shellerrors.TransactionNotSupportedError{}
+	}
+	if strings.Contains(err.Error(), "context canceled") {
+		err = &shellerrors.CancelQueryContextError{}
+	}
+
+	return err
 }

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -76,10 +76,6 @@ func NewShell(config ShellConfig, db *db.Db) (*Shell, error) {
 }
 
 func (sh *Shell) Run() error {
-	err := sh.resetState()
-	if err != nil {
-		return err
-	}
 	defer sh.state.readline.Close()
 
 	if !sh.config.QuietMode {
@@ -125,7 +121,6 @@ func (sh *Shell) resetState() error {
 	if err != nil {
 		return err
 	}
-	sh.state.readline.CaptureExitSignal()
 
 	sh.state.insideMultilineStatement = false
 	sh.state.statementParts = make([]string, 0)
@@ -221,4 +216,8 @@ func (sh *Shell) getWelcomeMessage() string {
 		return DEFAULT_WELCOME_MESSAGE
 	}
 	return *sh.config.WelcomeMessage
+}
+
+func (sh *Shell) CancelQuery() {
+	sh.db.CancelQuery()
 }

--- a/pkg/shell/shellerrors/errors.go
+++ b/pkg/shell/shellerrors/errors.go
@@ -19,6 +19,15 @@ func (e *TransactionNotSupportedError) userError() string {
 	return "transactions are only supported in the shell using semicolons to separate each statement.\nFor example: \"BEGIN; [your SQL statements]; END\""
 }
 
+type CancelQueryContextError struct{}
+
+func (e *CancelQueryContextError) Error() string {
+	return e.userError()
+}
+func (e *CancelQueryContextError) userError() string {
+	return "query canceled by the user"
+}
+
 type UrlDoesNotContainHostError struct{}
 
 func (e *UrlDoesNotContainHostError) Error() string {


### PR DESCRIPTION
## Description

This PR aims to add a way to cancel running queries in the shell.

## Related Issues

- Closes #90 

## Visual reference

![image](https://github.com/libsql/libsql-shell-go/assets/34041575/93a204c1-e269-46db-9fe3-d51c19835130)
