### PR TITLE
feat(ci): run sqld server on ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    services:
+      sqld:
+        image: ghcr.io/libsql/sqld:latest
+        ports:
+          - 8080:8080
+
     steps:
       - uses: actions/checkout@v3
 
@@ -40,4 +47,5 @@ jobs:
       - name: Test
         run: go test -v ./...
         env:
-          TEST_CONFIG_SKIP_SQLD_TESTS: 1
+          TEST_CONFIG_SQLD_DB_PATH: "http://127.0.0.1:8080"
+          TEST_CONFIG_SKIP_SQLD_TESTS: 0

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -92,7 +92,7 @@ func NewDb(dbPath string) (*Db, error) {
 func (db *Db) TestConnection() error {
 	_, err := db.sqlDb.Exec("SELECT 1;")
 	if err != nil {
-		return fmt.Errorf("failed to connect to database")
+		return fmt.Errorf("failed to connect to database. err: %v", err)
 	}
 	return nil
 }

--- a/test/utils/db_test_context.go
+++ b/test/utils/db_test_context.go
@@ -26,10 +26,10 @@ type DbTestContext struct {
 func NewTestContext(t *testing.T, dbPath string) *DbTestContext {
 	db, err := db.NewDb(dbPath)
 	if err != nil {
-		t.Fatalf("Fail to create new db")
+		t.Fatalf("Fail to create new db. err: %v", err)
 	}
 	if err := db.TestConnection(); err != nil {
-		db = nil
+		t.Fatalf("Fail to test connection. err: %v", err)
 	}
 
 	return &DbTestContext{T: t, C: qt.New(t), dbPath: dbPath, db: db}


### PR DESCRIPTION
## Description

- runs an sqld instance on the CI
- set skip_sqld_tests env variable to false

## Related Issues

- Closes #105 
