### PR TITLE
feat: add auth flag to pass token

### DIFF
--- a/.test_config.yaml.example
+++ b/.test_config.yaml.example
@@ -1,2 +1,3 @@
 sqld_db_path: "<your-sqld-db-test>"
+auth_token: "<your-jwt-token>"
 skip_sqld_tests: false

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 type RootArgs struct {
 	statements string
 	quiet      bool
+	authToken  string
 }
 
 func NewRootCmd() *cobra.Command {
@@ -32,6 +33,7 @@ func NewRootCmd() *cobra.Command {
 				HistoryMode: enums.PerDatabaseHistory,
 				HistoryName: "libsql",
 				QuietMode:   rootArgs.quiet,
+				AuthToken:   rootArgs.authToken,
 			}
 
 			if cmd.Flag("exec").Changed {
@@ -48,6 +50,7 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.Flags().StringVarP(&rootArgs.statements, "exec", "e", "", "SQL statements separated by ;")
 	rootCmd.Flags().BoolVarP(&rootArgs.quiet, "quiet", "q", false, "Don't print welcome message")
+	rootCmd.Flags().StringVar(&rootArgs.authToken, "auth", "", "Add a JWT Token.")
 
 	return rootCmd
 }

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -13,6 +13,7 @@ import (
 
 type ShellConfig struct {
 	DbPath                    string
+	AuthToken                 string
 	InF                       io.Reader
 	OutF                      io.Writer
 	ErrF                      io.Writer
@@ -26,7 +27,7 @@ type ShellConfig struct {
 func RunShell(config ShellConfig) error {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-	db, err := db.NewDb(config.DbPath)
+	db, err := db.NewDb(config.DbPath, config.AuthToken)
 	if err != nil {
 		return err
 	}
@@ -56,7 +57,7 @@ func RunShell(config ShellConfig) error {
 func RunShellLine(config ShellConfig, line string) error {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-	db, err := db.NewDb(config.DbPath)
+	db, err := db.NewDb(config.DbPath, config.AuthToken)
 	if err != nil {
 		return err
 	}

--- a/test/db_root_command_shell_test.go
+++ b/test/db_root_command_shell_test.go
@@ -12,8 +12,9 @@ import (
 type DBRootCommandShellSuite struct {
 	suite.Suite
 
-	dbPath string
-	tc     *utils.DbTestContext
+	dbPath    string
+	authToken string
+	tc        *utils.DbTestContext
 }
 
 func NewDBRootCommandShellSuite(dbPath string) *DBRootCommandShellSuite {
@@ -21,7 +22,7 @@ func NewDBRootCommandShellSuite(dbPath string) *DBRootCommandShellSuite {
 }
 
 func (s *DBRootCommandShellSuite) SetupSuite() {
-	s.tc = utils.NewTestContext(s.T(), s.dbPath)
+	s.tc = utils.NewTestContext(s.T(), s.dbPath, s.authToken)
 	s.tc.DropAllTables()
 }
 

--- a/test/root_command_exec_test.go
+++ b/test/root_command_exec_test.go
@@ -13,8 +13,9 @@ import (
 type RootCommandExecSuite struct {
 	suite.Suite
 
-	dbPath string
-	tc     *utils.DbTestContext
+	dbPath    string
+	authToken string
+	tc        *utils.DbTestContext
 }
 
 func NewRootCommandExecSuite(dbPath string) *RootCommandExecSuite {
@@ -22,7 +23,7 @@ func NewRootCommandExecSuite(dbPath string) *RootCommandExecSuite {
 }
 
 func (s *RootCommandExecSuite) SetupSuite() {
-	s.tc = utils.NewTestContext(s.T(), s.dbPath)
+	s.tc = utils.NewTestContext(s.T(), s.dbPath, s.authToken)
 	s.tc.DropAllTables()
 }
 

--- a/test/root_command_shell_test.go
+++ b/test/root_command_shell_test.go
@@ -12,16 +12,17 @@ import (
 type RootCommandShellSuite struct {
 	suite.Suite
 
-	dbPath string
-	tc     *utils.DbTestContext
+	dbPath    string
+	authToken string
+	tc        *utils.DbTestContext
 }
 
-func NewRootCommandShellSuite(dbPath string) *RootCommandShellSuite {
-	return &RootCommandShellSuite{dbPath: dbPath}
+func NewRootCommandShellSuite(dbPath string, authToken string) *RootCommandShellSuite {
+	return &RootCommandShellSuite{dbPath: dbPath, authToken: authToken}
 }
 
 func (s *RootCommandShellSuite) SetupSuite() {
-	s.tc = utils.NewTestContext(s.T(), s.dbPath)
+	s.tc = utils.NewTestContext(s.T(), s.dbPath, s.authToken)
 	s.tc.DropAllTables()
 }
 
@@ -84,7 +85,7 @@ func (s *RootCommandShellSuite) TestRootCommandShell_WhenSplittingStatementsInto
 }
 
 func TestRootCommandShellSuite_WhenDbIsSQLite(t *testing.T) {
-	suite.Run(t, NewRootCommandShellSuite(t.TempDir()+"test.sqlite"))
+	suite.Run(t, NewRootCommandShellSuite(t.TempDir()+"test.sqlite", ""))
 }
 
 func TestRootCommandShellSuite_WhenDbIsSqld(t *testing.T) {
@@ -93,5 +94,5 @@ func TestRootCommandShellSuite_WhenDbIsSqld(t *testing.T) {
 		t.Skip("Skipping Sqld tests due configuration")
 	}
 
-	suite.Run(t, NewRootCommandShellSuite(testConfig.SqldDbPath))
+	suite.Run(t, NewRootCommandShellSuite(testConfig.SqldDbPath, testConfig.AuthToken))
 }

--- a/test/utils/configs.go
+++ b/test/utils/configs.go
@@ -21,6 +21,7 @@ const (
 
 type TestConfig struct {
 	SkipSqldTests bool   `koanf:"skip_sqld_tests"`
+	AuthToken     string `koanf:"auth_token"`
 	SqldDbPath    string `koanf:"sqld_db_path" validate:"required_if=SkipSqldTests false"`
 }
 

--- a/test/utils/db_test_context.go
+++ b/test/utils/db_test_context.go
@@ -23,8 +23,8 @@ type DbTestContext struct {
 	db *db.Db
 }
 
-func NewTestContext(t *testing.T, dbPath string) *DbTestContext {
-	db, err := db.NewDb(dbPath)
+func NewTestContext(t *testing.T, dbPath string, authToken string) *DbTestContext {
+	db, err := db.NewDb(dbPath, authToken)
 	if err != nil {
 		t.Fatalf("Fail to create new db. err: %v", err)
 	}


### PR DESCRIPTION
## Description

This PR aims to add a new  `auth` flag that the user can use to pass the db token

## Related Issues

- Closes #101 

## Visual reference

![image](https://github.com/libsql/libsql-shell-go/assets/34041575/0530fa5a-e36b-44c6-8125-0d64b8ed6364)
