### PR TITLE
fix: add ; to sql statements in schema cmd

### DIFF
--- a/internal/shellcmd/schemas.go
+++ b/internal/shellcmd/schemas.go
@@ -17,7 +17,7 @@ var schemaCmd = &cobra.Command{
 			return fmt.Errorf("missing db connection")
 		}
 
-		schemaStatement := `select sql from sqlite_schema
+		schemaStatement := `select sql || ';' from sqlite_schema
 			where name not like 'sqlite_%'
 			and name != '_litestream_seq'
 			and name != '_litestream_lock'


### PR DESCRIPTION
## Description

Have concatenated the SQL statements with `;` at the end, so that it becomes easier to work with them in the shell.
Would that be sufficient? I hope the schema has valid and complete SQL statements.
<!--- Describe your changes in detail -->

## Related Issues

- Closes #129 

## Visual reference

![image](https://github.com/libsql/libsql-shell-go/assets/40317114/3840ad4c-a31e-4e3a-bc4c-db51def7e02c)

<!--- Please include screenshots, gifs or recordings  -->
<!--- For example: if this is a bug fix, provide before and after screenshots -->

Let me know if this is a valid fix or please provide me with the right direction and intuition to fix this.
Thank you.