### PR TITLE
Enhance .dump and .schema

### DIFF
--- a/internal/shellcmd/schemas.go
+++ b/internal/shellcmd/schemas.go
@@ -27,7 +27,7 @@ var schemaCmd = &cobra.Command{
 			schemaStatement += " and name like '" + args[0] + "'"
 		}
 
-		schemaStatement += " order by name"
+		schemaStatement += " order by tbl_name"
 
 		return config.Db.ExecuteAndPrintStatements(schemaStatement, config.OutF, true, enums.TABLE_MODE)
 	},

--- a/internal/shellcmd/schemas.go
+++ b/internal/shellcmd/schemas.go
@@ -17,7 +17,7 @@ var schemaCmd = &cobra.Command{
 			return fmt.Errorf("missing db connection")
 		}
 
-		schemaStatement := `select sql from sqlite_schema
+		schemaStatement := `select sql || ';' from sqlite_schema
 			where name not like 'sqlite_%'
 			and name != '_litestream_seq'
 			and name != '_litestream_lock'

--- a/test/db_root_command_shell_test.go
+++ b/test/db_root_command_shell_test.go
@@ -47,7 +47,7 @@ func (s *DBRootCommandShellSuite) Test_GivenADBWithTwoTables_WhenCallDotSchemaCo
 	outSchema, errS, err := s.tc.ExecuteShell([]string{".schema"})
 	s.tc.Assert(err, qt.IsNil)
 	s.tc.Assert(errS, qt.Equals, "")
-	s.tc.Assert(outSchema, qt.Equals, utils.GetPrintTableOutput([]string{""}, [][]string{{"CREATE TABLE another_simple_table (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER)\nCREATE TABLE simple_table (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER)"}}))
+	s.tc.Assert(outSchema, qt.Equals, utils.GetPrintTableOutput([]string{""}, [][]string{{"CREATE TABLE another_simple_table (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER);\nCREATE TABLE simple_table (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER);"}}))
 }
 
 func (s *DBRootCommandShellSuite) Test_GivenADBWithTwoTables_WhenCallDotSchemaCommandWithPattern_ExpectToReturnOneSchema() {
@@ -57,7 +57,7 @@ func (s *DBRootCommandShellSuite) Test_GivenADBWithTwoTables_WhenCallDotSchemaCo
 	outSchema, errS, err := s.tc.ExecuteShell([]string{".schema simple_table"})
 	s.tc.Assert(err, qt.IsNil)
 	s.tc.Assert(errS, qt.Equals, "")
-	s.tc.Assert(outSchema, qt.Equals, utils.GetPrintTableOutput([]string{""}, [][]string{{"CREATE TABLE simple_table (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER)"}}))
+	s.tc.Assert(outSchema, qt.Equals, utils.GetPrintTableOutput([]string{""}, [][]string{{"CREATE TABLE simple_table (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER);"}}))
 }
 
 func (s *DBRootCommandShellSuite) Test_GivenADBWithThreeTables_WhenCallDotSchemaCommandWithPartialDbName_ExpectToReturnTwoSchemas() {
@@ -68,7 +68,7 @@ func (s *DBRootCommandShellSuite) Test_GivenADBWithThreeTables_WhenCallDotSchema
 	outSchema, errS, err := s.tc.ExecuteShell([]string{".schema test%"})
 	s.tc.Assert(err, qt.IsNil)
 	s.tc.Assert(errS, qt.Equals, "")
-	s.tc.Assert(outSchema, qt.Equals, utils.GetPrintTableOutput([]string{""}, [][]string{{"CREATE TABLE test_table_one (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER)\nCREATE TABLE test_table_two (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER)"}}))
+	s.tc.Assert(outSchema, qt.Equals, utils.GetPrintTableOutput([]string{""}, [][]string{{"CREATE TABLE test_table_one (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER);\nCREATE TABLE test_table_two (id INTEGER PRIMARY KEY, textField TEXT, intField INTEGER);"}}))
 }
 
 func (s *DBRootCommandShellSuite) Test_GivenADBWithTwoTables_WhenCallDotSchemaCommandWithPatternThatDoesNotMatch_ExpectEmptyReturn() {
@@ -227,7 +227,7 @@ func (s *DBRootCommandShellSuite) Test_GivenATableWithRecords_WhenCreateIndexAnd
 	s.tc.Assert(err, qt.IsNil)
 	s.tc.Assert(errS, qt.Equals, "")
 
-	expected := "PRAGMA foreign_keys=OFF;\nCREATE TABLE alltypes (textNullable text, textNotNullable text NOT NULL, textWithDefault text DEFAULT 'defaultValue', \n\tintNullable INTEGER, intNotNullable INTEGER NOT NULL, intWithDefault INTEGER DEFAULT '0', \n\tfloatNullable REAL, floatNotNullable REAL NOT NULL, floatWithDefault REAL DEFAULT '0.0', \n\tunknownNullable NUMERIC, unknownNotNullable NUMERIC NOT NULL, unknownWithDefault NUMERIC DEFAULT 0.0, \n\tblobNullable BLOB, blobNotNullable BLOB NOT NULL, blobWithDefault BLOB DEFAULT 'x\"0\"');\nCREATE INDEX idx_textNullable on alltypes (textNullable)CREATE INDEX idx_intNotNullable on alltypes (intNotNullable) WHERE intNotNullable > 1;"
+	expected := "PRAGMA foreign_keys=OFF;\nCREATE TABLE alltypes (textNullable text, textNotNullable text NOT NULL, textWithDefault text DEFAULT 'defaultValue', \n\tintNullable INTEGER, intNotNullable INTEGER NOT NULL, intWithDefault INTEGER DEFAULT '0', \n\tfloatNullable REAL, floatNotNullable REAL NOT NULL, floatWithDefault REAL DEFAULT '0.0', \n\tunknownNullable NUMERIC, unknownNotNullable NUMERIC NOT NULL, unknownWithDefault NUMERIC DEFAULT 0.0, \n\tblobNullable BLOB, blobNotNullable BLOB NOT NULL, blobWithDefault BLOB DEFAULT 'x\"0\"');\nCREATE INDEX idx_textNullable on alltypes (textNullable);\nCREATE INDEX idx_intNotNullable on alltypes (intNotNullable) WHERE intNotNullable > 1;"
 
 	s.tc.AssertSqlEquals(outS, expected)
 }


### PR DESCRIPTION
## Description

Changes `.dump` and `.schema` commands to support triggers, multiple indexes, multiple tables, and so on.

## Related Issues

- Closes #134
- Closes #138 
- Closes #129 

## Visual reference
Before:
```sql
→  .schema
CREATE TRIGGER a AFTER INSERT ON q BEGIN     
SELECT 1;                                    
END                                          
CREATE INDEX bar ON t (t)                    
CREATE UNIQUE INDEX foo ON t (t)             
CREATE TABLE q (t text)                      
CREATE TRIGGER q AFTER INSERT ON t BEGIN     
SELECT 1;                                    
END                                          
CREATE TABLE t (t text)                      
CREATE TRIGGER t AFTER INSERT ON t BEGIN     
SELECT 1;                                    
END                                          
→  .dump
PRAGMA foreign_keys=OFF;
CREATE TABLE t (t text)CREATE TRIGGER t AFTER INSERT ON t BEGIN
SELECT 1;
ENDCREATE TRIGGER q AFTER INSERT ON t BEGIN
SELECT 1;
END;
INSERT INTO t VALUES ('x');
CREATE UNIQUE INDEX foo ON t (t)CREATE INDEX bar ON t (t);
CREATE TABLE q (t text)CREATE TRIGGER a AFTER INSERT ON q BEGIN
SELECT 1;
END;
INSERT INTO q VALUES ('x');
```
After:
```sql
→  .schema
CREATE TABLE q (t text);
CREATE TRIGGER a AFTER INSERT ON q BEGIN
SELECT 1;
END;
CREATE TABLE t (t text);
CREATE TRIGGER t AFTER INSERT ON t BEGIN
SELECT 1;
END;
CREATE UNIQUE INDEX foo ON t (t);
CREATE INDEX bar ON t (t);
CREATE TRIGGER q AFTER INSERT ON t BEGIN
SELECT 1;
END;
→  .dump
PRAGMA foreign_keys=OFF;
CREATE TABLE t (t text);
INSERT INTO t VALUES ('x');
CREATE TRIGGER t AFTER INSERT ON t BEGIN
SELECT 1;
END;
CREATE UNIQUE INDEX foo ON t (t);
CREATE INDEX bar ON t (t);
CREATE TRIGGER q AFTER INSERT ON t BEGIN
SELECT 1;
END;
CREATE TABLE q (t text);
INSERT INTO q VALUES ('x');
CREATE TRIGGER a AFTER INSERT ON q BEGIN
SELECT 1;
END;
```