### PR TITLE
fix: internal cmds escape special chars

### DIFF
--- a/internal/db/utils.go
+++ b/internal/db/utils.go
@@ -3,6 +3,7 @@ package db
 import (
 	"net/url"
 	"strings"
+	"unicode"
 )
 
 func IsUrl(uri string) bool {
@@ -23,4 +24,24 @@ func IsValidSqldUrl(uri string) (bool, string) {
 
 func EscapeSingleQuotes(value string) string {
 	return strings.Replace(value, "'", "''", -1)
+}
+
+func startsWithNumber(name string) bool {
+	firstChar := rune(name[0])
+	return unicode.IsNumber(firstChar)
+}
+
+func NeedsEscaping(name string) bool {
+	if len(name) == 0 {
+		return true
+	}
+	if startsWithNumber(name) {
+		return true
+	}
+	for _, char := range name {
+		if !unicode.IsLetter(char) && !unicode.IsNumber(char) && char != rune('_') {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/shellcmd/dump.go
+++ b/internal/shellcmd/dump.go
@@ -76,7 +76,12 @@ func dumpTableRecords(tableRecordsStatementResult db.StatementResult, config *Db
 		if tableRecordsRowResult.Err != nil {
 			return tableRecordsRowResult.Err
 		}
-		insertStatement := "INSERT INTO " + tableName + " VALUES ("
+
+		var formattedTableName = tableName
+		if db.NeedsEscaping(tableName) {
+			formattedTableName = "'" + db.EscapeSingleQuotes(tableName) + "'"
+		}
+		insertStatement := "INSERT INTO " + formattedTableName + " VALUES ("
 
 		tableRecordsFormattedRow, err := db.FormatData(tableRecordsRowResult.Row, db.SQLITE)
 		if err != nil {
@@ -109,8 +114,9 @@ func getTableSchema(config *DbCmdConfig, tableName string) (string, string, erro
 	var createTableStatement string
 	var createIndexStatement string
 	const INDEX = "INDEX"
+	formattedTableName := db.EscapeSingleQuotes(tableName)
 	tableInfoResult, err := config.Db.ExecuteStatements(
-		fmt.Sprintf("SELECT SQL FROM sqlite_master WHERE TBL_NAME='%s'", tableName),
+		fmt.Sprintf("SELECT SQL FROM sqlite_master WHERE TBL_NAME='%s'", formattedTableName),
 	)
 	if err != nil {
 		return "", "", err
@@ -140,8 +146,9 @@ func getTableSchema(config *DbCmdConfig, tableName string) (string, string, erro
 }
 
 func getTableRecords(config *DbCmdConfig, tableName string) (db.StatementResult, error) {
+	formattedTableName := db.EscapeSingleQuotes(tableName)
 	tableRecordsResult, err := config.Db.ExecuteStatements(
-		fmt.Sprintf("SELECT * FROM %s", tableName),
+		fmt.Sprintf("SELECT * FROM '%s'", formattedTableName),
 	)
 	if err != nil {
 		return db.StatementResult{}, err

--- a/test/db_root_command_shell_test.go
+++ b/test/db_root_command_shell_test.go
@@ -247,6 +247,30 @@ func (s *DBRootCommandShellSuite) Test_GivenATableWithRecordsWithSingleQuote_Whe
 	s.tc.AssertSqlEquals(outS, expected)
 }
 
+func (s *DBRootCommandShellSuite) Test_GivenATableNameStartingWithNumber_WhenCalllDotDumpCommand_ExpectCorrectFormat() {
+	s.tc.CreateSimpleTable("'8test'", []utils.SimpleTableEntry{{TextField: "Value", IntField: 1}})
+
+	outS, errS, err := s.tc.ExecuteShell([]string{".dump"})
+	s.tc.Assert(err, qt.IsNil)
+	s.tc.Assert(errS, qt.Equals, "")
+
+	expected := "pragma foreign_keys=off;\ncreate table '8test' (id integer primary key, textfield text, intfield integer);\ninsert into '8test' values (1, 'value', 1);"
+
+	s.tc.AssertSqlEquals(outS, expected)
+}
+
+func (s *DBRootCommandShellSuite) Test_GivenATableNameWithSpecialCharacters_WhenCallDotDumpCommand_ExpectCorrectFormat() {
+	s.tc.CreateSimpleTable("'t+e(s!t?'", []utils.SimpleTableEntry{{TextField: "Value", IntField: 1}})
+
+	outS, errS, err := s.tc.ExecuteShell([]string{".dump"})
+	s.tc.Assert(err, qt.IsNil)
+	s.tc.Assert(errS, qt.Equals, "")
+
+	expected := "pragma foreign_keys=off;\ncreate table 't+e(s!t?' (id integer primary key, textfield text, intfield integer);\ninsert into 't+e(s!t?' values (1, 'value', 1);"
+
+	s.tc.AssertSqlEquals(outS, expected)
+}
+
 func (s *DBRootCommandShellSuite) Test_GivenATableWithRecordsWithSingleQuote_WhenCalllSelectAllFromTable_ExpectSingleQuoteScape() {
 	s.tc.CreateEmptySimpleTable("t")
 	_, errS, err := s.tc.Execute("INSERT INTO t VALUES (0, \"x'x\", 0)")

--- a/test/utils/db_test_context.go
+++ b/test/utils/db_test_context.go
@@ -145,7 +145,11 @@ func (tc *DbTestContext) CreateAllTypesTable(tableName string, initialValues []A
 }
 
 func (tc *DbTestContext) DropTable(tableName string) {
-	_, _, err := tc.Execute("DROP TABLE " + tableName)
+	name := tableName
+	if db.NeedsEscaping(tableName) {
+		name = fmt.Sprintf("'%s'", db.EscapeSingleQuotes(tableName))
+	}
+	_, _, err := tc.Execute("DROP TABLE " + name)
 	tc.Assert(err, qt.IsNil)
 }
 
@@ -155,7 +159,11 @@ func (tc *DbTestContext) getAllTables() []string {
 	if strings.TrimSpace(result) == "" {
 		return []string{}
 	}
-	return strings.Split(result, "\n")
+	names := strings.Split(result, "\n")
+	for i, name := range names {
+		names[i] = strings.TrimSpace(name)
+	}
+	return names
 }
 
 func (tc *DbTestContext) DropAllTables() {


### PR DESCRIPTION
## Description



## Related Issues

- Closes #139 

## Visual reference

Before:
```
→  create table [asdf'asdf] (t text);
→  insert into [asdf'asdf] values ('x');
→  .dump
...
Error: failed to execute SQL: SELECT SQL FROM sqlite_master WHERE TBL_NAME='asdf'asdf'
syntax error around L1:56: `asdf`
```

Now:

```
→  create table [asdf'asdf] (t text);
→  insert into [asdf'asdf] values ('test');
→  create table '8test' (t text);
→  insert into '8test' values ('t');
→  create table 't(e!s?t+' (t text);
→  insert into 't(e!s?t+' values ('t');
→  .dump
PRAGMA foreign_keys=OFF;
CREATE TABLE [asdf'asdf] (t text);
INSERT INTO 'asdf''asdf' VALUES ('test');
CREATE TABLE '8test' (t text);
INSERT INTO '8test' VALUES ('t');
CREATE TABLE 't(e!s?t+' (t text);
INSERT INTO 't(e!s?t+' VALUES ('t');
→  .schema
CREATE TABLE '8test' (t text)         
CREATE TABLE [asdf'asdf] (t text)     
CREATE TABLE 't(e!s?t+' (t text)
→  .tables
8test         
asdf'asdf     
t(e!s?t+ 
```

